### PR TITLE
fix(lambda-feed): attach presigned url to cached results, as image_url

### DIFF
--- a/internal/pkg/util/types.go
+++ b/internal/pkg/util/types.go
@@ -29,6 +29,7 @@ type ImageDocument struct {
 	Title       string `json:"title" dynamodbav:"title"`
 	Author      string `json:"author" dynamodbav:"author"`
 	Image       string `json:"image" dynamodbav:"image"`
+	ImageURL    string `json:"image_url,omitempty"`
 }
 
 type QueueResponse struct {
@@ -58,6 +59,6 @@ type ProgressRequest struct {
 
 type ProgressResponse struct {
 	DocumentID string `json:"id"`
-	ImageURL string `json:"imageurl"`
-	Progress int `json:"progress"`
+	ImageURL   string `json:"imageurl"`
+	Progress   int    `json:"progress"`
 }

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -61,7 +61,7 @@ func SortDocuments(documents []ImageDocument) {
 	sort.Slice(
 		documents,
 		func(i, j int) bool {
-			return documents[i].DateCreated < documents[j].DateCreated
+			return documents[i].DateCreated > documents[j].DateCreated
 		},
 	)
 }


### PR DESCRIPTION
Attaching presigned url under the `image_url` property on ImageDocument now to avoid caching yuckiness.

Also attaching new presigned URL to results, even when cache is hit.